### PR TITLE
Add save wafer map image option

### DIFF
--- a/waferview/gui/semimap.py
+++ b/waferview/gui/semimap.py
@@ -46,6 +46,8 @@ class Viewer(wx.Panel):
             dc.SetBrush(wx.Brush(color, style=wx.BRUSHSTYLE_SOLID))
             dc.DrawRectangleList(rects)
 
+        return dc
+
     def generate_map(self, filename):
         """Generate the wafermap bitmap objects."""
         self.wmap = wafermap.WaferMap(filename)


### PR DESCRIPTION
## Description:
Adds a save utility for the wafer map

**Related issue (if applicable):** fixes #10

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
