### PR TITLE
Fix float in draw

### DIFF
--- a/waferview/gui/semimap.py
+++ b/waferview/gui/semimap.py
@@ -40,7 +40,7 @@ class Viewer(wx.Panel):
         xScale = self.zoom_factor * min(width, height) / self.scale[0]
         yScale = self.zoom_factor * min(width, height) / self.scale[1]
         dc.SetUserScale(xScale, yScale)
-        dc.SetLogicalOrigin(self.xorigin, self.yorigin)
+        dc.SetLogicalOrigin(int(self.xorigin), int(self.yorigin))
         for key, rects in self.pixel_elements.items():
             try:
                 color = self.color_map[key]

--- a/waferview/gui/semimap.py
+++ b/waferview/gui/semimap.py
@@ -42,7 +42,6 @@ class Viewer(wx.Panel):
         dc.SetUserScale(xScale, yScale)
         dc.SetLogicalOrigin(self.xorigin, self.yorigin)
         for key, rects in self.pixel_elements.items():
-            print(rects)
             try:
                 color = self.color_map[key]
             except KeyError:

--- a/waferview/gui/semimap.py
+++ b/waferview/gui/semimap.py
@@ -42,6 +42,7 @@ class Viewer(wx.Panel):
         dc.SetUserScale(xScale, yScale)
         dc.SetLogicalOrigin(self.xorigin, self.yorigin)
         for key, rects in self.pixel_elements.items():
+            print(rects)
             try:
                 color = self.color_map[key]
             except KeyError:
@@ -71,10 +72,10 @@ class Viewer(wx.Panel):
         )
         for pixel in self.wmap.pixels:
             loc = (
-                pixel[0][0] * self.scale[0] + self.xoffset,
-                pixel[0][1] * self.scale[1] + self.yoffset,
+                int(pixel[0][0] * self.scale[0] + self.xoffset),
+                int(pixel[0][1] * self.scale[1] + self.yoffset),
             )
-            size = (pixel[1][0] * self.scale[0], pixel[1][1] * self.scale[1] - 1)
+            size = (int(pixel[1][0] * self.scale[0]), int(pixel[1][1] * self.scale[1]))
             color = wx.Colour(constants.NULL_COLOR)
             if pixel[2]:
                 color = wx.Colour(constants.PASS_COLOR)


### PR DESCRIPTION
## Description:
Ensures all rectangles are integers, not float

**Related issue (if applicable):** fixes #25 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
